### PR TITLE
Fix formatDate to return the right time

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "connect-flash": "^0.1.1",
     "connect-redis": "^4.0.4",
     "cookie-parser": "^1.4.5",
-    "date-fns": "^2.15.0",
+    "date-fns": "^2.17.0",
     "domelementtype": "^2.0.1",
     "ejs": "^3.1.3",
     "express": "^4.17.1",

--- a/src/utils/TimeHelper.ts
+++ b/src/utils/TimeHelper.ts
@@ -1,4 +1,5 @@
 import * as fs from 'date-fns'
+const moment = require('moment');
 
 export default class TimeHelper {
 
@@ -9,8 +10,8 @@ export default class TimeHelper {
     }
 
     public static formatDate(time: any, hidetime: true): string {
-        const format = (hidetime) ? "MMMM d, yyyy" : "MMMM dd, yyyy HH:MM:ss" ;
-        return fs.format(new Date(fs.parseISO(time)), format);
+        const format = (hidetime) ? "MMMM DD, YYYY" : "MMMM DD, YYYY HH:mm:ss";
+        return moment(new Date(time)).format(format);
     }
 
     public static formatTime(millis: any): string {


### PR DESCRIPTION
Needs npm install - to update date-fns just in case due to https://github.com/date-fns/date-fns/issues/1618

And fixes https://github.com/Quaver/Quaver.Website/issues/289