### PR TITLE
WIP: Use correct badge for mapsets

### DIFF
--- a/src/static/css/quaver.css
+++ b/src/static/css/quaver.css
@@ -784,6 +784,22 @@ h1, h2, h3, h4, h5, h6, .h1, .h2, .h3, .h4, .h5, .h6 {
     background: #F9645D;
 }
 
+.mapsets .status .status-pending {
+    background: #F2994A;
+}
+
+.mapsets .status .status-blacklisted {
+    background: #1f1f1f;
+}
+
+.mapsets .status .status-onhold {
+    background: #959299;
+}
+
+.mapsets .status .status-resolved {
+    background: #9468C3;
+}
+
 .mapsets .status .mapset-4k {
     background: #0587E5;
 }

--- a/src/views/maps/mapsets.twig
+++ b/src/views/maps/mapsets.twig
@@ -50,7 +50,7 @@
                             {% elseif map.ranking_status == 2 %}
                                 <div class="qadge status-blacklisted">Blacklisted</div>
                             {% elseif map.ranking_status == 3 %}
-                                <div class="qadge status-onhold">OnHold</div>
+                                <div class="qadge status-onhold">On Hold</div>
                             {% elseif map.ranking_status == 4 %}
                                 <div class="qadge status-resolved">Resolved</div>
                             {% elseif map.ranking_status == 5 %}

--- a/src/views/maps/mapsets.twig
+++ b/src/views/maps/mapsets.twig
@@ -44,7 +44,16 @@
                             {% else %}
                                 <div class="qadge mapset-7k">7K</div>
                             {% endif %}
-                            {% if map.ranked_status == 2 %}
+                            {% if map.ranking_status == 0 %}
+                                <div class="qadge status-pending">Pending</div>
+							{# Denied = 1 -> Back to unranked #}
+                            {% elseif map.ranking_status == 2 %}
+                                <div class="qadge status-blacklisted">Blacklisted</div>
+                            {% elseif map.ranking_status == 3 %}
+                                <div class="qadge status-onhold">OnHold</div>
+                            {% elseif map.ranking_status == 4 %}
+                                <div class="qadge status-resolved">Resolved</div>
+                            {% elseif map.ranking_status == 5 %}
                                 <div class="qadge status-ranked">Ranked</div>
                             {% else %}
                                 <div class="qadge status-unranked">Unranked</div>


### PR DESCRIPTION
This requires a new field when fetching mapsets from the API. In addition to `ranked_status` which follows this enum (starting at 0):
- `NotSubmitted`
- `Unranked`
- `Ranked`
- `Playlist`

, the new field `ranking_status` describes the mapset's state in regards to the ranking process, according to the existing enum in the ranking queue (starting at 0):
- `Pending`
- `Denied`
- `Blacklisted`
- `OnHold`
- `Resolved`
- `Ranked`

`Denied` or any value strictly greater than `Ranked` or lower than `Pending` is considered `Unranked`.
Reminder, the two statuses should still both be in place, this is additional information.
This implementation heavily relies on the existing codebase and aims at making minimal changes.

Cannot be merged until tested via an api update